### PR TITLE
docs: fix simple typo, sentencs -> sentences

### DIFF
--- a/Part2_Text_Classify/cnn-text-classification-tf-chinese/data_helpers.py
+++ b/Part2_Text_Classify/cnn-text-classification-tf-chinese/data_helpers.py
@@ -79,7 +79,7 @@ def build_vocab(sentences):
 
 def build_input_data(sentences, labels, vocabulary):
   """
-  Maps sentencs and labels to vectors based on a vocabulary.
+  Maps sentences and labels to vectors based on a vocabulary.
   """
   x = np.array([[vocabulary[word] for word in sentence] for sentence in sentences])
   y = np.array(labels)


### PR DESCRIPTION
There is a small typo in Part2_Text_Classify/cnn-text-classification-tf-chinese/data_helpers.py.

Should read `sentences` rather than `sentencs`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md